### PR TITLE
fix empty cart bug and fix the npm run format script

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,13 +1,15 @@
-import { getLocalStorage } from './utils.mjs'
+import { getLocalStorage } from './utils.mjs';
 
 function renderCartContents() {
-  const cartItems = getLocalStorage('so-cart')
-  
-  if (cartItems === null){
-    document.querySelector('.product-list').innerHTML = 'Your cart could use a healthy dose of camping gear to get the fun started!'
-  } else
-  {const htmlItems = cartItems.map((item) => cartItemTemplate(item))
-  document.querySelector('.product-list').innerHTML = htmlItems.join('')}
+  const cartItems = getLocalStorage('so-cart');
+
+  if (cartItems === null) {
+    document.querySelector('.product-list').innerHTML =
+      'Your cart could use a healthy dose of camping gear to get the fun started!';
+  } else {
+    const htmlItems = cartItems.map((item) => cartItemTemplate(item));
+    document.querySelector('.product-list').innerHTML = htmlItems.join('');
+  }
 }
 
 function cartItemTemplate(item) {
@@ -24,9 +26,9 @@ function cartItemTemplate(item) {
   <p class='cart-card__color'>${item.Colors[0].ColorName}</p>
   <p class='cart-card__quantity'>qty: 1</p>
   <p class='cart-card__price'>$${item.FinalPrice}</p>
-</li>`
+</li>`;
 
-  return newItem
+  return newItem;
 }
 
-renderCartContents()
+renderCartContents();

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,9 +1,13 @@
-import { getLocalStorage } from './utils.mjs';
+import { getLocalStorage } from './utils.mjs'
 
 function renderCartContents() {
-  const cartItems = getLocalStorage('so-cart');
-  const htmlItems = cartItems.map((item) => cartItemTemplate(item));
-  document.querySelector('.product-list').innerHTML = htmlItems.join('');
+  const cartItems = getLocalStorage('so-cart')
+  
+  if (cartItems === null){
+    document.querySelector('.product-list').innerHTML = 'Your cart could use a healthy dose of camping gear to get the fun started!'
+  } else
+  {const htmlItems = cartItems.map((item) => cartItemTemplate(item))
+  document.querySelector('.product-list').innerHTML = htmlItems.join('')}
 }
 
 function cartItemTemplate(item) {
@@ -20,9 +24,9 @@ function cartItemTemplate(item) {
   <p class='cart-card__color'>${item.Colors[0].ColorName}</p>
   <p class='cart-card__quantity'>qty: 1</p>
   <p class='cart-card__price'>$${item.FinalPrice}</p>
-</li>`;
+</li>`
 
-  return newItem;
+  return newItem
 }
 
-renderCartContents();
+renderCartContents()


### PR DESCRIPTION
Here is a screenshot of the task that this pr is for:

![image](https://user-images.githubusercontent.com/74209907/235545722-a2f8442a-7bd5-43a4-951b-42ec0a33518a.png)

When the cart was empty, the console was throwing an error because it was trying to do array.map() on a null value. I changed it so if the value of `cartItems` is null, it just renders a string instead of trying to render the `cartItems`.