### PR TITLE
adds cart count as superscript to backpack icon

### DIFF
--- a/src/cart/index.html
+++ b/src/cart/index.html
@@ -11,17 +11,18 @@
     <link rel="stylesheet" href="/css/style.css" />
 
     <script src="../js/cart.js" type="module"></script>
+    <script type="module" src="../js/header.js"></script>
   </head>
 
   <body>
     <header class="divider">
       <div class="logo">
-        <img src="images/noun_Tent_2517.svg" alt="tent image for logo" />
+        <img src="../images/noun_Tent_2517.svg" alt="tent image for logo" />
         <a href="/index.html"> Sleep<span class="highlight">Outside</span></a>
       </div>
 
       <div class="cart">
-        <a href="../cart/index.html">
+        <a href="../cart/index.html" id="cart-link">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <path
               d="M18.9 32.6c1.1 2.4 2.5 3.3 5.4 3.3 1.6 0 3.6-0.3 5.9-0.6 3.2-0.5 6.9-1 11.2-1 2.1 0 4.3 0.1 6.4 0.3 2.1 0.1 4.2 0.3 6.1 0.3 3.2 0 5.2-0.4 5.9-1.2 2.7-2.7 2.8-8.8 2.9-14.6 0.1-6.7 0.2-14.5 4.6-18.7 -0.5 0-1 0-1.6 0 -14.2 0-37.5 0-41.1 0C15.6 6.2 14.9 23.6 18.9 32.6z"
@@ -50,6 +51,7 @@
             <!-- <text x="0" y="115" fill="#000000" font-size="5px" font-weight="bold" font-family="'Helvetica Neue', Helvetica, Arial-Unicode, Arial, Sans-serif">Created by Natalia Woodroffe</text>
             <text x="0" y="120" fill="#000000" font-size="5px" font-weight="bold" font-family="'Helvetica Neue', Helvetica, Arial-Unicode, Arial, Sans-serif">from the Noun Project</text> -->
           </svg>
+          <span id="item-count"></span>
         </a>
       </div>
     </header>
@@ -58,38 +60,7 @@
       <section class="products">
         <h2>My Cart</h2>
 
-        <ul class="product-list">
-          <!-- <li class="cart-card divider">
-            <a href="product_pages/marmot-ajax-3.html" class="cart-card__image">
-              <img
-                src="images/tents/marmot-ajax-tent-3-person-3-season-in-pale-pumpkin-terracotta~p~880rr_01~320.jpg"
-                alt="Marmot Ajax tent"
-              />
-            </a>
-            <a href="product_pages/marmot-ajax-3.html">
-              <h2 class="card__name">Marmot Ajax Tent - 3-Person, 3-Season</h2>
-            </a>
-            <p class="cart-card__color">Pale Pumpkin/Terracotta</p>
-            <p class="cart-card__quantity">qty: 1</p>
-            <p class="cart-card__price">$199.99</p>
-          </li>
-          <li class="cart-card divider">
-            <a href="product_pages/marmot-ajax-3.html" class="cart-card__image">
-              <img
-                src="images/tents/the-north-face-talus-tent-4-person-3-season-in-golden-oak-saffron-yellow~p~985rf_01~320.jpg"
-                alt="Talus Tent - 4-Person, 3-Season"
-              />
-            </a>
-            <a href="product_pages/marmot-ajax-3.html">
-              <h2 class="card__name">
-                The North Face Talus Tent - 4-Person, 3-Season
-              </h2></a
-            >
-            <p class="cart-card__color">Golden Oak/Saffron Yellow</p>
-            <p class="cart-card__quantity">qty: 1</p>
-            <p class="cart-card__price">$199.99</p>
-          </li> -->
-        </ul>
+        <div class="product-list"></div>
       </section>
     </main>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -110,6 +110,24 @@ button {
   fill: gray;
 }
 
+.cart:hover #item-count {
+  background-color: #ffd8b6;
+}
+
+#item-count {
+  position: absolute;
+  background-color: var(--primary-color);
+  color: black;
+  padding: 1px 4px;
+  border-radius: 7px;
+  font-size: 11px;
+  margin: -7px 0 0 -11px;
+}
+
+#cart-link {
+  text-decoration: none;
+}
+
 /* End cart icon styles */
 
 .mission {

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
     <title>Sleep Outside | Home</title>
     <link rel="stylesheet" href="/css/style.css" />
     <script type="module" src="./js/main.js"></script>
+    <script type="module" src="./js/header.js"></script>
   </head>
   <body>
     <header class="divider">
@@ -14,7 +15,7 @@
         <a href="index.html"> Sleep<span class="highlight">Outside</span></a>
       </div>
       <div class="cart">
-        <a href="cart/index.html">
+        <a href="cart/index.html" id="cart-link">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <path
               d="M18.9 32.6c1.1 2.4 2.5 3.3 5.4 3.3 1.6 0 3.6-0.3 5.9-0.6 3.2-0.5 6.9-1 11.2-1 2.1 0 4.3 0.1 6.4 0.3 2.1 0.1 4.2 0.3 6.1 0.3 3.2 0 5.2-0.4 5.9-1.2 2.7-2.7 2.8-8.8 2.9-14.6 0.1-6.7 0.2-14.5 4.6-18.7 -0.5 0-1 0-1.6 0 -14.2 0-37.5 0-41.1 0C15.6 6.2 14.9 23.6 18.9 32.6z"
@@ -38,6 +39,7 @@
             <!-- <text x="0" y="115" fill="#000000" font-size="5px" font-weight="bold" font-family="'Helvetica Neue', Helvetica, Arial-Unicode, Arial, Sans-serif">Created by Natalia Woodroffe</text>
             <text x="0" y="120" fill="#000000" font-size="5px" font-weight="bold" font-family="'Helvetica Neue', Helvetica, Arial-Unicode, Arial, Sans-serif">from the Noun Project</text> -->
           </svg>
+          <span id="item-count"></span>
         </a>
       </div>
     </header>
@@ -64,9 +66,7 @@
       </section>
       <section class="products">
         <h2>Top Products</h2>
-        <div class="product-list">
-          
-        </div>
+        <div class="product-list"></div>
       </section>
     </main>
     <footer>&copy;NOT a real business</footer>

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -16,7 +16,7 @@ function cartItemTemplate(item) {
   const newItem = `<li class='cart-card divider'>
   <a href='#' class='cart-card__image'>
     <img
-      src='${item.Image}'
+      src='../${item.Image}'
       alt='${item.Name}'
     />
   </a>

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -1,0 +1,4 @@
+import { getCartItemCount } from './utils.mjs';
+
+// add the count of items in the cart to the backpack icon
+document.getElementById('item-count').textContent = getCartItemCount();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,3 @@
-import productList from './productList.mjs'
+import productList from './productList.mjs';
 
-//console.log(productList('tents'));
 productList('tents', '.product-list');

--- a/src/js/productDetails.mjs
+++ b/src/js/productDetails.mjs
@@ -35,6 +35,10 @@ function addProductToCart(product) {
 async function addToCartHandler(e) {
   const product = await findProductById(e.target.dataset.id)
   addProductToCart(product)
+  
+  // update the backpack superscript count on add to cart
+  const cartItemCount = document.getElementById('item-count')
+  cartItemCount.textContent = Number(cartItemCount.textContent) + 1
 }
 document
   .getElementById('addToCart')

--- a/src/js/productDetails.mjs
+++ b/src/js/productDetails.mjs
@@ -4,7 +4,6 @@ import { findProductById } from './productData.mjs';
 export default async function productDetails(productId){
   const productData = await findProductById(productId)
   renderProductDetails(productData)
-  console.log(productData)
 }
 
 function renderProductDetails(productData){

--- a/src/js/utils.mjs
+++ b/src/js/utils.mjs
@@ -33,3 +33,9 @@ export function renderListWithTemplate(templateFn, parentElement, list){
   const html = list.map((item) => templateFn(item));
   parentElement.innerHTML = html;
 }
+
+export function getCartItemCount(){
+  const cartItems = getLocalStorage('so-cart')
+  if (cartItems===null) return 0
+  return cartItems.length
+}

--- a/src/product_pages/index.html
+++ b/src/product_pages/index.html
@@ -11,17 +11,18 @@
     <link rel="stylesheet" href="../css/style.css" />
 
     <script src="../js/product.js" type="module"></script>
+    <script type="module" src="../js/header.js"></script>
   </head>
 
   <body>
     <header class="divider">
       <div class="logo">
-        <img src="images/noun_Tent_2517.svg" alt="tent image for logo" />
+        <img src="../images/noun_Tent_2517.svg" alt="tent image for logo" />
         <a href="../index.html"> Sleep<span class="highlight">Outside</span></a>
       </div>
 
       <div class="cart">
-        <a href="../cart/index.html">
+        <a href="../cart/index.html" id="cart-link">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <path
               d="M18.9 32.6c1.1 2.4 2.5 3.3 5.4 3.3 1.6 0 3.6-0.3 5.9-0.6 3.2-0.5 6.9-1 11.2-1 2.1 0 4.3 0.1 6.4 0.3 2.1 0.1 4.2 0.3 6.1 0.3 3.2 0 5.2-0.4 5.9-1.2 2.7-2.7 2.8-8.8 2.9-14.6 0.1-6.7 0.2-14.5 4.6-18.7 -0.5 0-1 0-1.6 0 -14.2 0-37.5 0-41.1 0C15.6 6.2 14.9 23.6 18.9 32.6z"
@@ -50,6 +51,7 @@
             <!-- <text x="0" y="115" fill="#000000" font-size="5px" font-weight="bold" font-family="'Helvetica Neue', Helvetica, Arial-Unicode, Arial, Sans-serif">Created by Natalia Woodroffe</text>
             <text x="0" y="120" fill="#000000" font-size="5px" font-weight="bold" font-family="'Helvetica Neue', Helvetica, Arial-Unicode, Arial, Sans-serif">from the Noun Project</text> -->
           </svg>
+          <span id="item-count"></span>
         </a>
       </div>
     </header>


### PR DESCRIPTION
![image](https://github.com/lsneth/SleepOutside/assets/74209907/aa6df6e0-213d-4ca5-93f4-7c214ccd34a3)

- adds cart count as superscript to backpack icon
- updates count when add to cart is clicked
- fixes some more img src attributes that were wrong
- remove console logs
